### PR TITLE
Dismiss method for delegate

### DIFF
--- a/Example/HSAttachmentPicker/HSAttachmentPickerViewController.m
+++ b/Example/HSAttachmentPicker/HSAttachmentPickerViewController.m
@@ -34,4 +34,8 @@
     NSLog(@"uploading %@", filename);
 }
 
+- (void)attachmentPickerMenuDismissed:(HSAttachmentPicker *)menu {
+    NSLog(@"dismissed");
+}
+
 @end

--- a/Example/HSAttachmentPicker/HSAttachmentPickerViewController.m
+++ b/Example/HSAttachmentPicker/HSAttachmentPickerViewController.m
@@ -2,19 +2,17 @@
 
 #import <HSAttachmentPicker/HSAttachmentPicker.h>
 
-@interface HSAttachmentPickerViewController () <HSAttachmentPickerDelegate> {
-    HSAttachmentPicker *_menu;
-}
+@interface HSAttachmentPickerViewController () <HSAttachmentPickerDelegate>
 
 @end
 
 @implementation HSAttachmentPickerViewController
 
 - (IBAction)openMenu:(id)sender {
-    _menu = [[HSAttachmentPicker alloc] init];
-    _menu.delegate = self;
-    _menu.translationTable = @"HSAttachmentPicker";
-    [_menu showAttachmentMenu];
+    HSAttachmentPicker *menu = [[HSAttachmentPicker alloc] init];
+    menu.delegate = self;
+    menu.translationTable = @"HSAttachmentPicker";
+    [menu showAttachmentMenu];
 }
 
 - (void)attachmentPickerMenu:(HSAttachmentPicker * _Nonnull)menu showController:(UIViewController * _Nonnull)controller completion:(void (^ _Nullable)(void))completion {

--- a/HSAttachmentPicker/Classes/HSAttachmentPicker.h
+++ b/HSAttachmentPicker/Classes/HSAttachmentPicker.h
@@ -2,7 +2,7 @@
 
 @class HSAttachmentPicker;
 
-@protocol HSAttachmentPickerDelegate
+@protocol HSAttachmentPickerDelegate<NSObject>
 
 -(void)attachmentPickerMenu:(HSAttachmentPicker *_Nonnull)menu showController:(UIViewController *_Nonnull)controller completion:(void (^_Nullable)(void))completion;
 
@@ -10,11 +10,14 @@
 
 -(void)attachmentPickerMenu:(HSAttachmentPicker *_Nonnull)menu upload:(NSData *_Nonnull)data filename:(NSString *_Nonnull)filename image:(UIImage *_Nullable)image;
 
+@optional
+-(void)attachmentPickerMenuDismissed:(HSAttachmentPicker *_Nonnull)menu;
+
 @end
 
 @interface HSAttachmentPicker : NSObject
 
-@property (nonatomic, weak, nullable) id<HSAttachmentPickerDelegate> delegate;
+@property (nonatomic, weak) id<HSAttachmentPickerDelegate> delegate;
 
 /**
  * This will default to NSBundle.mainBundle unless specified

--- a/HSAttachmentPicker/Classes/HSAttachmentPicker.h
+++ b/HSAttachmentPicker/Classes/HSAttachmentPicker.h
@@ -17,7 +17,7 @@
 
 @interface HSAttachmentPicker : NSObject
 
-@property (nonatomic, weak) id<HSAttachmentPickerDelegate> delegate;
+@property (nonatomic, weak, nonnull) id<HSAttachmentPickerDelegate> delegate;
 
 /**
  * This will default to NSBundle.mainBundle unless specified

--- a/HSAttachmentPicker/Classes/HSAttachmentPicker.h
+++ b/HSAttachmentPicker/Classes/HSAttachmentPicker.h
@@ -17,7 +17,7 @@
 
 @interface HSAttachmentPicker : NSObject
 
-@property (nonatomic, weak, nonnull) id<HSAttachmentPickerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<HSAttachmentPickerDelegate> delegate;
 
 /**
  * This will default to NSBundle.mainBundle unless specified

--- a/HSAttachmentPicker/Classes/HSAttachmentPicker.m
+++ b/HSAttachmentPicker/Classes/HSAttachmentPicker.m
@@ -6,11 +6,15 @@
 #import "HSAttachmentPickerPhotoPreviewController.h"
 
 @interface HSAttachmentPicker () <HSAttachmentPickerPhotoPreviewControllerDelegate, UIDocumentMenuDelegate, UIDocumentPickerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+
+@property(nonatomic) HSAttachmentPicker *selfReference;
+
 @end
 
 @implementation HSAttachmentPicker
 
 -(void)showAttachmentMenu {
+    self.selfReference = self;
     UIAlertController *picker = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     NSString *showPhotosPermissionSettingsMessage = [NSBundle.mainBundle objectForInfoDictionaryKey:@"NSPhotoLibraryUsageDescription"];
     if ([UIImagePickerController isSourceTypeAvailable: UIImagePickerControllerSourceTypeCamera] && showPhotosPermissionSettingsMessage != nil) {
@@ -170,6 +174,7 @@
     if (self.delegate && [self.delegate respondsToSelector:@selector(attachmentPickerMenuDismissed:)]) {
         [self.delegate attachmentPickerMenuDismissed:self];
     }
+    self.selfReference = nil;
 }
 
 - (void)showError:(NSString *)errorMessage {

--- a/HSAttachmentPicker/Classes/HSAttachmentPicker.m
+++ b/HSAttachmentPicker/Classes/HSAttachmentPicker.m
@@ -51,7 +51,7 @@
     }];
     [picker addAction:cancelAction];
 
-    [_delegate attachmentPickerMenu:self showController:picker completion:nil];
+    [self.delegate attachmentPickerMenu:self showController:picker completion:nil];
 }
 
 #pragma mark - import file
@@ -60,7 +60,7 @@
         NSArray *documentTypes = [[NSArray alloc] initWithObjects:(NSString*)kUTTypeItem, nil];
         UIDocumentMenuViewController *documentMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:documentTypes inMode:UIDocumentPickerModeImport];
         documentMenu.delegate = self;
-        [_delegate attachmentPickerMenu:self showController:documentMenu completion:nil];
+        [self.delegate attachmentPickerMenu:self showController:documentMenu completion:nil];
     }
     @catch (NSException *exception) {
         [self showError:[self translateString:@"This application is not entitled to access iCloud"]];
@@ -70,7 +70,7 @@
 #pragma mark - use last photo
 -(void)useLastPhoto {
     PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
-    fetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:true]];
+    fetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:YES]];
     PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithMediaType:PHAssetMediaTypeImage options:fetchOptions];
     if (fetchResult.count == 0) {
         [self showError:[self translateString:@"There doesn't seem to be a photo taken yet."]];
@@ -114,12 +114,12 @@
 -(void)showImagePicker:(UIImagePickerControllerSourceType)sourceType {
     UIImagePickerController *imagePicker = [[UIImagePickerController alloc] init];
     imagePicker.delegate = self;
-    imagePicker.allowsEditing = false;
+    imagePicker.allowsEditing = NO;
     imagePicker.mediaTypes = [[NSArray alloc] initWithObjects:(NSString*)kUTTypeImage, (NSString*)kUTTypeMovie, nil];
     imagePicker.videoQuality = UIImagePickerControllerQualityTypeLow;
     imagePicker.sourceType = sourceType;
-    [_delegate attachmentPickerMenu:self showController:imagePicker completion:^{
-        UIApplication.sharedApplication.statusBarHidden = true;
+    [self.delegate attachmentPickerMenu:self showController:imagePicker completion:^{
+        UIApplication.sharedApplication.statusBarHidden = YES;
     }];
 }
 
@@ -209,7 +209,7 @@
     CGSize targetSize = photo.pixelWidth > photo.pixelHeight ? CGSizeMake(1024, 768) : CGSizeMake(768, 1024);
     requestOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
     requestOptions.resizeMode = PHImageRequestOptionsResizeModeExact;
-    requestOptions.synchronous = true;
+    requestOptions.synchronous = YES;
     [PHImageManager.defaultManager requestImageForAsset:photo targetSize:targetSize contentMode:PHImageContentModeAspectFit options:requestOptions resultHandler:^(UIImage *result, NSDictionary *info) {
         NSData *data = UIImageJPEGRepresentation(result, 0.5);
         NSString *filename = [photo valueForKey:@"filename"] ?: @"photo.jpg";
@@ -225,7 +225,8 @@
 #pragma mark - UIDocumentMenuDelegate
 -(void)documentMenu:(UIDocumentMenuViewController *)documentMenu didPickDocumentPicker:(UIDocumentPickerViewController *)documentPicker{
     documentPicker.delegate = self;
-    [_delegate attachmentPickerMenu:self showController:documentPicker completion:nil];
+    [self.delegate attachmentPickerMenu:self showController:documentPicker completion:nil];
+}
 
 -(void)documentMenuWasCancelled:(UIDocumentMenuViewController *)documentMenu {
     [self dismissed];
@@ -245,17 +246,17 @@
     if (picker.sourceType != UIImagePickerControllerSourceTypeCamera) {
         NSString *mediaType = info[UIImagePickerControllerMediaType];
         if ([mediaType isEqualToString:(NSString*)kUTTypeMovie]) {
-            [picker dismissViewControllerAnimated:true completion:nil];
+            [picker dismissViewControllerAnimated:YES completion:nil];
             [self uploadSavedMedia:info];
         } else {
             HSAttachmentPickerPhotoPreviewController *previewController = [[HSAttachmentPickerPhotoPreviewController alloc] init];
             previewController.delegate = self;
             previewController.info = info;
-            [picker pushViewController:previewController animated:true];
+            [picker pushViewController:previewController animated:YES];
         }
         return;
     }
-    [picker dismissViewControllerAnimated:true completion:nil];
+    [picker dismissViewControllerAnimated:YES completion:nil];
     if (info[UIImagePickerControllerMediaType] == (NSString*)kUTTypeMovie) {
         [self saveVideoFromCamera:info];
     } else {

--- a/README.md
+++ b/README.md
@@ -14,14 +14,10 @@
 You'll want to create a new `HSAttachmentPicker`, assign a delegate, and call `showAttachmentMenu`.
 
 ```objective-c
-menu = [[HSAttachmentPicker alloc] init];
+HSAttachmentPicker *menu = [[HSAttachmentPicker alloc] init];
 menu.delegate = self;
 [menu showAttachmentMenu];
 ```
-
-It's important you class holds a reference to the `HSAttachmentPicker` so it doesn't get garbage collected.
-
-
 
 
 ## Example


### PR DESCRIPTION
This adds a new method to the delegate to detect when the attachment picker was dismissed. Since there's now a single method that's always called on dismiss, we can keep a reference to `self` and not require clients to hold a reference to the picker anymore as we clear that reference on dismissing.

I've done some style clean up here of booleans and field references too.