### PR TITLE
Fix/ios 13 navigation bar

### DIFF
--- a/HSAttachmentPicker/HSAttachmentPicker.h
+++ b/HSAttachmentPicker/HSAttachmentPicker.h
@@ -19,6 +19,11 @@
 
 @property (nonatomic, weak, nullable) id<HSAttachmentPickerDelegate> delegate;
 
+
+/// The desired video quality to return selected movies in
+/// Defaults to UIImagePickerControllerQualityTypeMedium
+@property (nonatomic) UIImagePickerControllerQualityType preferredVideoQuality;
+
 /**
  * This will default to NSBundle.mainBundle unless specified
  */

--- a/HSAttachmentPicker/HSAttachmentPicker.m
+++ b/HSAttachmentPicker/HSAttachmentPicker.m
@@ -13,6 +13,14 @@
 
 @implementation HSAttachmentPicker
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.preferredVideoQuality = UIImagePickerControllerQualityTypeMedium;
+    }
+    return self;
+}
+
 -(void)showAttachmentMenu {
     self.selfReference = self;
     UIAlertController *picker = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -126,7 +134,7 @@
     imagePicker.delegate = self;
     imagePicker.allowsEditing = NO;
     imagePicker.mediaTypes = [[NSArray alloc] initWithObjects:(NSString*)kUTTypeImage, (NSString*)kUTTypeMovie, nil];
-    imagePicker.videoQuality = UIImagePickerControllerQualityTypeLow;
+    imagePicker.videoQuality = self.preferredVideoQuality;
     imagePicker.sourceType = sourceType;
     [self.delegate attachmentPickerMenu:self showController:imagePicker completion:^{
         UIApplication.sharedApplication.statusBarHidden = YES;

--- a/HSAttachmentPicker/HSAttachmentPicker.m
+++ b/HSAttachmentPicker/HSAttachmentPicker.m
@@ -269,6 +269,8 @@
             [self uploadSavedMedia:info];
         } else {
             HSAttachmentPickerPhotoPreviewController *previewController = [[HSAttachmentPickerPhotoPreviewController alloc] init];
+            previewController.translationsBundle = self.translationsBundle;
+            previewController.translationTable = self.translationTable;
             previewController.delegate = self;
             previewController.info = info;
             [picker pushViewController:previewController animated:YES];

--- a/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.h
+++ b/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.h
@@ -14,4 +14,14 @@
 
 @property (nonatomic, strong, nonnull) NSDictionary<NSString *,id> *info;
 
+/**
+ * This will default to NSBundle.mainBundle unless specified
+ */
+@property (nonatomic, nullable) NSBundle *translationsBundle;
+
+/**
+ * Use this specific .strings file for translations, uses system default (Localizable.strings) otherwise
+ */
+@property (nonatomic, nullable) NSString *translationTable;
+
 @end

--- a/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.m
+++ b/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.m
@@ -1,5 +1,11 @@
 #import "HSAttachmentPickerPhotoPreviewController.h"
 
+@interface HSAttachmentPickerPhotoPreviewController ()
+
+@property (nonatomic) BOOL wasNavigationBarHidden;
+
+@end
+
 @implementation HSAttachmentPickerPhotoPreviewController
 
 - (void)viewDidLoad {
@@ -12,6 +18,24 @@
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[self translateString:@"Use"] style:UIBarButtonItemStyleDone target:self action:@selector(usePhoto)];
 }
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    if (self.navigationController.navigationBarHidden) {
+        [self.navigationController setNavigationBarHidden:NO];
+        self.wasNavigationBarHidden = YES;
+    }
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+
+    if (self.wasNavigationBarHidden) {
+        [self.navigationController setNavigationBarHidden:YES];
+    }
+}
+
 
 -(void)usePhoto {
     [self.navigationController dismissViewControllerAnimated:true completion:nil];

--- a/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.m
+++ b/HSAttachmentPicker/HSAttachmentPickerPhotoPreviewController.m
@@ -8,14 +8,19 @@
     self.view = image;
     self.view.backgroundColor = UIColor.whiteColor;
     self.view.contentMode = UIViewContentModeScaleAspectFit;
-    self.title = @"Preview";
+    self.title = [self translateString:@"Preview"];
     
-    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Use" style:UIBarButtonItemStyleDone target:self action:@selector(usePhoto)];
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[self translateString:@"Use"] style:UIBarButtonItemStyleDone target:self action:@selector(usePhoto)];
 }
 
 -(void)usePhoto {
     [self.navigationController dismissViewControllerAnimated:true completion:nil];
     [_delegate photoPreview:self usePhoto:self.info];
+}
+
+- (NSString *)translateString:(NSString *)key {
+    NSBundle *bundle = self.translationsBundle ? self.translationsBundle : NSBundle.mainBundle;
+    return [bundle localizedStringForKey:key value:nil table:self.translationTable];
 }
 
 @end


### PR DESCRIPTION
### What Is The Goal?

There's a few:

- Allow for clients to set the desired video quality of selected movies
- Allow for clients to set translations on the `HSAttachmentPickerPhotoPreviewController`
- Fix an issue on iOS 13 where the navigation bar would be hidden

### How Is It Implemented?

- `HSAttachmentPicker` now has a `preferredVideoQuality` property 
- `HSAttachmentPickerPhotoPreviewController` now has a `translationsBundle` and `translationsTable` property which the `HSAttachmentPicker` object sets accordingly
- `HSAttachmentPickerPhotoPreviewController` now tracks when being presented if its navigationControllers `navigationBar` was hidden.  If it is hidden then it unhides the `navigationBar` and hides it when the `viewWillDisappear`