### PR TITLE
[IOSSDK-270] Fix taking photo or video callback on background thread

### DIFF
--- a/HSAttachmentPicker/HSAttachmentPicker.m
+++ b/HSAttachmentPicker/HSAttachmentPicker.m
@@ -146,14 +146,16 @@
         PHAssetChangeRequest *request = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:url];
         placeholder[@"asset"] = request.placeholderForCreatedAsset;
     } completionHandler:^(BOOL success, NSError * _Nullable error) {
-        if (success) {
-            NSData *contents = [NSFileManager.defaultManager contentsAtPath:url.path];
-            NSString *filename = [NSString stringWithFormat:@"%@.mov", NSUUID.UUID.UUIDString];
-            [self upload:contents filename:filename image:nil];
-        } else {
-            NSString *errorMessage = [NSString stringWithFormat:[self translateString:@"Unable to save video: %@"], error.localizedDescription];
-            [self showError:errorMessage];
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                NSData *contents = [NSFileManager.defaultManager contentsAtPath:url.path];
+                NSString *filename = [NSString stringWithFormat:@"%@.mov", NSUUID.UUID.UUIDString];
+                [self upload:contents filename:filename image:nil];
+            } else {
+                NSString *errorMessage = [NSString stringWithFormat:[self translateString:@"Unable to save video: %@"], error.localizedDescription];
+                [self showError:errorMessage];
+            }
+        });
     }];
 }
 
@@ -162,12 +164,14 @@
         UIImage *image = info[UIImagePickerControllerOriginalImage];
         [PHAssetChangeRequest creationRequestForAssetFromImage:image];
     } completionHandler:^(BOOL success, NSError * _Nullable error) {
-        if (success) {
-            [self useLastPhoto];
-        } else {
-            NSString *errorMessage = [NSString stringWithFormat:[self translateString:@"Unable to save photo: %@"], error.localizedDescription];
-            [self showError:errorMessage];
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                [self useLastPhoto];
+            } else {
+                NSString *errorMessage = [NSString stringWithFormat:[self translateString:@"Unable to save photo: %@"], error.localizedDescription];
+                [self showError:errorMessage];
+            }
+        });
     }];
 }
 


### PR DESCRIPTION
From [Apple's documentation](https://developer.apple.com/documentation/photokit/phphotolibrary/1620743-performchanges) on the `peformChanges` method.

> Photos executes both the change block and the completion handler block on an arbitrary serial queue. To update your app’s UI as a result of a change, dispatch that work to the main queue.

We were not calling the result on the `completionHandler` on the main thread causing the issue on the `ChatViewController` on Beacon.